### PR TITLE
Replace "Show more results" string with prop

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -49,6 +49,7 @@ class RawFileBrowser extends React.Component {
     showFoldersOnFilter: PropTypes.bool,
     noFilesMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     noMatchingFilesMessage: PropTypes.func,
+    showMoreResults: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
     group: PropTypes.func.isRequired,
     sort: PropTypes.func.isRequired,
@@ -115,6 +116,7 @@ class RawFileBrowser extends React.Component {
     showFoldersOnFilter: false,
     noFilesMessage: 'No files.',
     noMatchingFilesMessage: (filter) => `No files matching "${filter}".`,
+    showMoreResults: 'Show more results',
 
     group: GroupByFolder,
     sort: SortByName,
@@ -750,7 +752,7 @@ class RawFileBrowser extends React.Component {
                       onClick={this.handleShowMoreClick}
                       href="#"
                     >
-                      Show more results
+                      {this.props.showMoreResults}
                     </a>
                   </td>
                 </tr>
@@ -798,7 +800,7 @@ class RawFileBrowser extends React.Component {
                   onClick={this.handleShowMoreClick}
                   href="#"
                 >
-                  Show more results
+                  {this.props.showMoreResults}
                 </a>
               )
             }

--- a/stories/index.js
+++ b/stories/index.js
@@ -40,6 +40,14 @@ const files = [
   },
 ]
 
+const moreThan20Files = Array(21).fill(
+  {
+    key: 'cat.png',
+    modified: subHours(new Date(), 1).getTime(),
+    size: 1.5 * 1024 * 1024,
+  },
+)
+
 const store = new Store({ files })
 const dndStore = new Store({ files })
 
@@ -95,6 +103,45 @@ export const differentRendersAndGroupers = () => (
     group={Groupers.GroupByModifiedRelative}
     fileRenderer={FileRenderers.ListThumbnailFile}
     folderRenderer={FolderRenderers.ListThumbnailFolder}
+  />
+)
+
+export const customerRenderAndCustomNoMatchingFilesMessage = () => (
+  <>
+    <p>Search for a string not contained in the file names in order to see the custom No Results message.</p>
+    <FileBrowser
+      files={files}
+      actionRenderer={() => (
+        <ul className="item-actions">
+          <li key="action-sample">
+            <a
+              href="#"
+              role="button"
+            >
+              Do nothing
+            </a>
+          </li>
+        </ul>
+      )}
+      noMatchingFilesMessage={(filter) => `There are no files that match "${filter}".`}
+    />
+  </>
+)
+
+export const moreThan20FilesWithCustomShowMore = () => (
+  <>
+    <p>Search for "cat" to see the Show More Results message at the bottom of the table.</p>
+    <FileBrowser
+      files={moreThan20Files}
+      showMoreResults="Show me more results"
+    />
+  </>
+)
+
+export const emptyFilesListWithCustomNoFilesMessage = () => (
+  <FileBrowser
+    files={[]}
+    noFilesMessage="There are no files."
   />
 )
 


### PR DESCRIPTION
Replaced "Show more results" string with prop to match the props used for "No files" and "No files matching *". As far as I can tell, this string was the last one that was not able to be customized before this commit via custom Renderer components or props.

I was going to add tests, since that was one of the checkboxes in your PR into the main project, but there don't seem to be tests at all in the project so I think we're good there.

I added a few Storybook stories to show that all of the props that customize strings are working. Shown below:
![image](https://user-images.githubusercontent.com/576752/138941254-7199b324-8b7c-4155-9057-6b98dbcf6c66.png)
![image](https://user-images.githubusercontent.com/576752/138941337-bbb0000c-0ff0-45b7-9e9f-7746a3cb5826.png)
![image](https://user-images.githubusercontent.com/576752/138941420-d0f83bde-c08b-4be2-8985-d15b03913075.png)
